### PR TITLE
Remove package attributes from AndroidManifest + added JVM compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,15 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.piccmaq.disk_space_plus">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
I removed package attributes in AndroidManifest to prevent 
``` 
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
``` 
error during build phase. Which only happen when you upgrade Android Gradle Plugin to version 8.0+.

I also added JVM toolchain [compatibility](https://stackoverflow.com/questions/69079963/how-to-set-compilejava-task-11-and-compilekotlin-task-1-8-jvm-target-com).

Tested on my app using OPPO Reno 5 Pro (API 33) and Android API 34 emulator.