### PR TITLE
Fix compileSdkVersion on newer flutter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,11 +25,14 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 android {
     namespace 'com.piccmaq.disk_space_plus'
 
-    compileSdkVersion 30
+    compileSdkVersion safeExtGet('compileSdkVersion', 30)
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Make a non-breaking change to ensure compatibility with the newer Flutter version and enable our app to build successfully.

in Android/build.gradle add:
```

ext {
    compileSdkVersion   = 34
}
```