### PR TITLE
Fixes getFreeDiskSpace to return free disk space

### DIFF
--- a/lib/disk_space_plus.dart
+++ b/lib/disk_space_plus.dart
@@ -13,7 +13,7 @@ class DiskSpacePlus {
   }
 
   Future<double?> get getFreeDiskSpace async {
-    return DiskSpacePlusPlatform.instance.getTotalDiskSpace;
+    return DiskSpacePlusPlatform.instance.getFreeDiskSpace;
   }
 
   Future<double?> get getTotalDiskSpace async {


### PR DESCRIPTION
Changes
```
Future<double?> get getFreeDiskSpace async {
    return DiskSpacePlusPlatform.instance.getTotalDiskSpace;
}
```
to return
`DiskSpacePlusPlatform.instance.getFreeDiskSpace`

This Closes #11 